### PR TITLE
Add ordered dictionary

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,83 @@ local rmean = require('algo.rmean')
 local my_collector = rmean.collector('my_collector')
 ```
 
+## Ordered Dictionary (algo.odict)
+
+The collection tracks the order in which the items are added and provides
+`algo.odict.pairs()` function to get them in this order.
+
+The ordered dictionary is a usual Lua table with a specific metatable. All the
+table operations are applicable.
+
+It is similar to Python's [collections.OrderedDict][python-odict].
+
+[python-odict]: https://docs.python.org/3/library/collections.html#collections.OrderedDict
+
+Example:
+
+```lua
+local od = odict.new()
+
+od.a = 1
+od.b = 2
+od.c = 3
+
+print('od.a', od.a) -- 1
+print('od.b', od.b) -- 2
+print('od.c', od.c) -- 3
+
+for k, v in odict.pairs(od) do
+    print(k, v)
+end
+-- print: a, 1
+-- print: b, 2
+-- print: c, 3
+```
+
+If an element is changed (without prior deletion), it remains on the same
+position.
+
+```lua
+local od = odict.new()
+
+od.a = 1
+od.b = 2
+od.c = 3
+
+od.b = 4
+
+for k, v in odict.pairs(od) do
+    print(k, v)
+end
+-- print: a, 1
+-- print: b, 4
+-- print: c, 3
+```
+
+If an element is deleted and added again, it is added to the end.
+
+```lua
+local od = odict.new()
+
+od.a = 1
+od.b = 2
+od.c = 3
+
+od.b = nil
+od.b = 4
+
+for k, v in odict.pairs(od) do
+    print(k, v)
+end
+-- print: a, 1
+-- print: c, 3
+-- print: b, 4
+```
+
+Beware: Tarantool's REPL shows the fields as unordered. The same for the
+serialization into JSON/YAML/MessagePack formats. It should be solved after
+https://github.com/tarantool/tarantool/issues/9747.
+
 #### Observing Values and Calculating Metrics
 
 ```lua

--- a/algo.lua
+++ b/algo.lua
@@ -2,5 +2,6 @@ return {
 	rlist = require 'algo.rlist',
 	heap  = require 'algo.heap',
 	rmean = require 'algo.rmean',
+	odict = require 'algo.odict',
 	_VERSION = '0.1.0',
 }

--- a/algo/odict.lua
+++ b/algo/odict.lua
@@ -10,7 +10,7 @@ local function gen(od, prev_key)
 
     -- The previous key is nil only on the first call of the
     -- generator function.
-    local id = prev_key == nil and 0 or ctx.key2id[prev_key]
+    local id = type(prev_key) == 'nil' and 0 or ctx.key2id[prev_key]
     -- NB: This assert doesn't catch all the kinds of changes
     -- during an iteration. It rather verifies a precondition
     -- for the following cycle.
@@ -25,7 +25,7 @@ local function gen(od, prev_key)
         -- id2key may contain a stalled entry, because __newindex
         -- is not called on assignment of an existing field,
         -- including assignment to nil.
-        if key ~= nil and od[key] ~= nil then
+        if type(key) ~= 'nil' and od[key] ~= nil then
             return key, od[key]
         end
     end
@@ -93,11 +93,11 @@ local function reindex(od, ctx)
     for id = 1, old_max_id do
         local key = ctx.id2key[id]
         -- Drop the given key-id pair from the key<->id mappings.
-        if key ~= nil then
+        if type(key) ~= 'nil' then
             release(ctx, key)
         end
         -- Add the new key-id pair into the key<->id mappings.
-        if key ~= nil and od[key] ~= nil then
+        if type(key) ~= 'nil' and od[key] ~= nil then
             track(ctx, key)
         end
     end

--- a/algo/odict.lua
+++ b/algo/odict.lua
@@ -1,0 +1,158 @@
+local REINDEX_THRESHOLD = 1000
+
+local registry = setmetatable({}, {__mode = 'k'})
+
+-- Generator function for odict.pairs().
+--
+-- Returns (key, value).
+local function gen(od, prev_key)
+    local ctx = registry[od]
+
+    -- The previous key is nil only on the first call of the
+    -- generator function.
+    local id = prev_key == nil and 0 or ctx.key2id[prev_key]
+    -- NB: This assert doesn't catch all the kinds of changes
+    -- during an iteration. It rather verifies a precondition
+    -- for the following cycle.
+    assert(id ~= nil, 'ordered dictionary is changed during iteration')
+
+    while id <= ctx.max_id do
+        id = id + 1
+        local key = ctx.id2key[id]
+        -- id2key may have holes for IDs <= max_id in place of
+        -- deleted items.
+        --
+        -- id2key may contain a stalled entry, because __newindex
+        -- is not called on assignment of an existing field,
+        -- including assignment to nil.
+        if key ~= nil and od[key] ~= nil then
+            return key, od[key]
+        end
+    end
+end
+
+-- Returns a Lua iterator triplet (gen, param, state).
+--
+-- Usage:
+--
+--  | for k, v in odict.pairs(od) do
+--  |     <...>
+--  | end
+--
+-- The iterator stability guarantees are the same as for usual
+-- pairs().
+--
+-- Quote from the Lua 5.1 reference manual:
+--
+-- > The behavior of `next` is undefined if, during the traversal,
+-- > you assign any value to a non-existent field in the table.
+-- > You may however modify existing fields. In particular, you
+-- > may clear existing fields.
+local function _pairs(od)
+    return gen, od, nil
+end
+
+-- Delete the key from the id<->key mappings.
+local function release(ctx, key)
+    local id = ctx.key2id[key]
+    if id ~= nil then
+        ctx.key2id[key] = nil
+        ctx.id2key[id] = nil
+
+        -- No need to grow the IDs if the same key is assigned and
+        -- deleted in a loop.
+        --
+        -- for <...> do
+        --     od.x = 'x'
+        --     od.x = nil
+        -- end
+        if id == ctx.max_id then
+            ctx.max_id = ctx.max_id - 1
+        end
+    end
+end
+
+-- Track the new key in the id<->key mappings.
+local function track(ctx, key)
+    local id = ctx.max_id + 1
+    ctx.id2key[id] = key
+    ctx.key2id[key] = id
+    ctx.max_id = id
+end
+
+-- Renew the id<->key mappings to eliminate holes.
+local function reindex(od, ctx)
+    -- This cycle reassigns IDs in the following way.
+    --
+    --    1     2     3     4
+    -- | foo | nil | bar | baz |
+    --          ^    | ^    |
+    --          +----+ +----+
+    local old_max_id = ctx.max_id
+    ctx.max_id = 0
+    for id = 1, old_max_id do
+        local key = ctx.id2key[id]
+        -- Drop the given key-id pair from the key<->id mappings.
+        if key ~= nil then
+            release(ctx, key)
+        end
+        -- Add the new key-id pair into the key<->id mappings.
+        if key ~= nil and od[key] ~= nil then
+            track(ctx, key)
+        end
+    end
+end
+
+local mt = {
+    __newindex = function(self, k, v)
+        local ctx = registry[self]
+
+        -- __newindex is never called on an existing field of a
+        -- table.
+        assert(rawget(self, k) == nil)
+
+        -- If a field with this key had existed, we should update
+        -- the key<->id mappings to let gen() know the new order.
+        release(ctx, k)
+
+        -- If a non-existing field is assigned to nil, we have
+        -- nothing to do.
+        if type(v) == 'nil' then
+            return
+        end
+
+        -- Add the value.
+        track(ctx, k)
+        rawset(self, k, v)
+
+        ctx.reindex_countdown = ctx.reindex_countdown - 1
+        assert(ctx.reindex_countdown >= 0)
+
+        -- We can't track density, because __newindex is not
+        -- called on assigning an existing field to nil.
+        --
+        -- Let's reindex every N assignments of a new non-nil
+        -- field, where N is the size of the dictionary (but not
+        -- less than REINDEX_THRESHOLD).
+        if ctx.reindex_countdown == 0 then
+            reindex(self, ctx)
+            ctx.reindex_countdown = math.max(ctx.max_id, REINDEX_THRESHOLD)
+        end
+    end,
+}
+
+local function new()
+    local res = setmetatable({}, mt)
+    registry[res] = {
+        id2key = {},
+        key2id = {},
+        max_id = 0,
+        reindex_countdown = REINDEX_THRESHOLD,
+    }
+    return res
+end
+
+return {
+    new = new,
+    pairs = _pairs,
+}

--- a/test/004_odict_test.lua
+++ b/test/004_odict_test.lua
@@ -1,0 +1,393 @@
+local t = require 'luatest' --[[@as luatest]]
+local g = t.group('odict')
+
+local fun = require 'fun'
+local odict = require 'algo.odict'
+
+g.test_set_get = function()
+    local od = odict.new()
+
+    od.a = 1
+    od.b = 2
+    od.c = 3
+
+    t.assert_equals(od.a, 1)
+    t.assert_equals(od.b, 2)
+    t.assert_equals(od.c, 3)
+end
+
+g.test_delete_non_existing = function()
+    local od = odict.new()
+
+    od.a = nil
+
+    t.assert_equals(od.a, nil)
+end
+
+g.test_delete = function()
+    local od = odict.new()
+
+    od.a = 1
+    od.b = 2
+    od.c = 3
+
+    od.b = nil
+
+    t.assert_equals(od.a, 1)
+    t.assert_equals(od.b, nil)
+    t.assert_equals(od.c, 3)
+end
+
+g.test_pairs = function()
+    local od = odict.new()
+
+    od.a = 1
+    od.b = 2
+    od.c = 3
+
+    local res = {}
+    for k, v in odict.pairs(od) do
+        table.insert(res, {k, v})
+    end
+    t.assert_equals(res, {
+        {'a', 1},
+        {'b', 2},
+        {'c', 3},
+    })
+end
+
+g.test_pairs_set = function()
+    local od = odict.new()
+
+    od.a = 1
+    od.b = 2
+    od.c = 3
+
+    od.b = 2.1
+
+    local res = {}
+    for k, v in odict.pairs(od) do
+        table.insert(res, {k, v})
+    end
+    t.assert_equals(res, {
+        {'a', 1},
+        {'b', 2.1},
+        {'c', 3},
+    })
+end
+
+
+g.test_pairs_delete = function()
+    local od = odict.new()
+
+    od.a = 1
+    od.b = 2
+    od.c = 3
+
+    od.b = nil
+
+    local res = {}
+    for k, v in odict.pairs(od) do
+        table.insert(res, {k, v})
+    end
+    t.assert_equals(res, {
+        {'a', 1},
+        {'c', 3},
+    })
+end
+
+g.test_pairs_delete_and_set = function()
+    local od = odict.new()
+
+    od.a = 1
+    od.b = 2
+    od.c = 3
+
+    od.b = nil
+    od.b = 4
+
+    local res = {}
+    for k, v in odict.pairs(od) do
+        table.insert(res, {k, v})
+    end
+    t.assert_equals(res, {
+        {'a', 1},
+        {'c', 3},
+        {'b', 4},
+    })
+end
+
+-- {{{ Helpers for reindexing test cases
+
+-- Parse a range expressed like Python's slice operator.
+--
+-- '1:3000' -> 1, 3000
+-- '1:3000:2' -> 1, 3000, 2
+--
+-- The result is suitable to pass into fun.range().
+local function parse_range(s)
+    local start, stop, step = unpack(s:split(':', 2))
+    start = tonumber(start)
+    stop = tonumber(stop)
+    step = tonumber(step)
+    return start, stop, step
+end
+
+-- Generate a value based on the given prefix and the given key.
+local function gen_value(prefix, key)
+    return ('%s-%s'):format(prefix, key)
+end
+
+local slice_mt = {
+    __newindex = function(self, k, v)
+        fun.range(parse_range(k)):each(function(k)
+            if type(v) == 'nil' then
+                self.od[k] = nil
+            else
+                self.od[k] = gen_value(v, k)
+            end
+        end)
+    end,
+}
+
+-- Bulk assign values to a table using a slicing operator, similar
+-- to Python's one.
+local function slice(od)
+    return setmetatable({od = od}, slice_mt)
+end
+
+-- Verify that the ordered dictionary returns given values in the
+-- given order.
+--
+-- The values are described in the following way.
+--
+-- {
+--     '<range> <prefix>',
+--     ...
+-- }
+--
+-- <range> is a start:stop or a start:stop:step string, see
+-- parse_range().
+--
+-- <prefix> is a value prefix, see gen_value().
+local function check(od, values)
+    local res = {}
+    for k, v in odict.pairs(od) do
+        table.insert(res, {k, v})
+    end
+
+    local exp = {}
+    for _, v in ipairs(values) do
+        local range_str, prefix = unpack(v:split(' ', 1))
+        fun.range(parse_range(range_str)):each(function(k)
+            table.insert(exp, {k, gen_value(prefix, k)})
+        end)
+    end
+
+    t.assert_equals(res, exp)
+end
+
+-- Access the internal registry of ordered dictionaries.
+local function registry()
+    for i = 1, debug.getinfo(odict.new).nups do
+        local name, var = debug.getupvalue(odict.new, i)
+        if name == 'registry' then
+            return var
+        end
+    end
+    assert(false)
+end
+
+-- Look on the maximum ID in the internal key<->id mappings.
+--
+-- Useful to verify that the reindexing actually occurs.
+local function max_id(od)
+    return registry()[od].max_id
+end
+
+-- }}} Helpers for reindexing test cases
+
+-- {{{ Reindexing test cases
+
+-- Fill 6000 values, clear first 3000, fill 3000 more. Verify that
+-- the order is correct for all the remaining values.
+--
+-- Sketchy illustration of these assignments is below.
+--
+--         1 .. 3000 .. 6000 .. 9000
+-- step 1   aaaa
+-- step 2   aaaa    bbbb
+-- step 3           bbbb
+-- step 4           bbbb    cccc
+--
+-- The expected order is bbbb cccc.
+g.test_reindex_delete_head = function()
+    local od = odict.new()
+
+    slice(od)['1:3000'] = 'aaaa'
+    slice(od)['3001:6000'] = 'bbbb'
+    slice(od)['1:3000'] = nil
+    slice(od)['6001:9000'] = 'cccc'
+
+    check(od, {
+        '3001:6000 bbbb',
+        '6001:9000 cccc',
+    })
+    t.assert_equals(max_id(od), 6000)
+end
+
+-- Fill 6000 values, clear first 3000, fill 3000 more, reassign
+-- first 3000 ones. Verify that the order is correct for all
+-- the remaining values.
+--
+-- Sketchy illustration of these assignments is below.
+--
+--         1 .. 3000 .. 6000 .. 9000
+-- step 1   aaaa
+-- step 2   aaaa    bbbb
+-- step 3           bbbb
+-- step 4           bbbb    cccc
+-- step 5   dddd    bbbb    cccc
+--
+-- The expected order is bbbb cccc dddd.
+g.test_reindex_reassing_head = function()
+    local od = odict.new()
+
+    slice(od)['1:3000'] = 'aaaa'
+    slice(od)['3001:6000'] = 'bbbb'
+    slice(od)['1:3000'] = nil
+    slice(od)['6001:9000'] = 'cccc'
+    slice(od)['1:3000'] = 'dddd'
+
+    check(od, {
+        '3001:6000 bbbb',
+        '6001:9000 cccc',
+        '1:3000 dddd',
+    })
+    t.assert_equals(max_id(od), 9000)
+end
+
+-- Fill 6000 values, clear last 3000 ones, fill 3000 more. Verify
+-- that the order is correct for all the remaining values.
+--
+-- Sketchy illustration of these assignments is below.
+--
+--         1 .. 3000 .. 6000 .. 9000
+-- step 1   aaaa
+-- step 2   aaaa    bbbb
+-- step 3   aaaa
+-- step 4   aaaa            cccc
+--
+-- The expected order is aaaa cccc.
+g.test_reindex_delete_middle = function()
+    local od = odict.new()
+
+    slice(od)['1:3000'] = 'aaaa'
+    slice(od)['3001:6000'] = 'bbbb'
+    slice(od)['3001:6000'] = nil
+    slice(od)['6001:9000'] = 'cccc'
+
+    check(od, {
+        '1:3000 aaaa',
+        '6001:9000 cccc',
+    })
+    t.assert_equals(max_id(od), 6000)
+end
+
+-- Fill 6000 values, clear last 3000 ones, fill 3000 more,
+-- reassing the cleared values. Verify that the order is
+-- correct for all the remaining values.
+--
+-- Sketchy illustration of these assignments is below.
+--
+--         1 .. 3000 .. 6000 .. 9000
+-- step 1   aaaa
+-- step 2   aaaa    bbbb
+-- step 3   aaaa
+-- step 4   aaaa            cccc
+-- step 5   aaaa    dddd    cccc
+--
+-- The expected order is aaaa cccc dddd.
+g.test_reindex_reassign_middle = function()
+    local od = odict.new()
+
+    slice(od)['1:3000'] = 'aaaa'
+    slice(od)['3001:6000'] = 'bbbb'
+    slice(od)['3001:6000'] = nil
+    slice(od)['6001:9000'] = 'cccc'
+    slice(od)['3001:6000'] = 'dddd'
+
+    check(od, {
+        '1:3000 aaaa',
+        '6001:9000 cccc',
+        '3001:6000 dddd',
+    })
+    t.assert_equals(max_id(od), 9000)
+end
+
+-- Fill 9000 values, clear the last 3000 ones. Verify that the
+-- order is correct for all the remaining values.
+--
+-- Sketchy illustration of these assignments is below.
+--
+--         1 .. 3000 .. 6000 .. 9000
+-- step 1   aaaa
+-- step 2   aaaa    bbbb
+-- step 3           bbbb    cccc
+-- step 4           bbbb
+--
+-- The expected order is aaaa bbbb.
+g.test_reindex_delete_tail = function()
+    local od = odict.new()
+
+    slice(od)['1:3000'] = 'aaaa'
+    slice(od)['3001:6000'] = 'bbbb'
+    slice(od)['6001:9000'] = 'cccc'
+    slice(od)['6001:9000'] = nil
+
+    check(od, {
+        '1:3000 aaaa',
+        '3001:6000 bbbb',
+    })
+
+    -- This test case doesn't involve reindexing after deletion of
+    -- the 6001:9000 fields. So, we check the order of remaining
+    -- values and don't check the maximum ID in the internal
+    -- key<->id mappings.
+end
+
+-- Fill 9000 values, clear the last 3000 ones, then reassign them.
+-- Verify that the order is correct for all the remaining values.
+--
+-- Sketchy illustration of these assignments is below.
+--
+--         1 .. 3000 .. 6000 .. 9000
+-- step 1   aaaa
+-- step 2   aaaa    bbbb
+-- step 3           bbbb    cccc
+-- step 4           bbbb
+-- step 5           bbbb    dddd
+--
+-- The expected order is aaaa bbbb dddd.
+g.test_reindex_reassign_tail = function()
+    local od = odict.new()
+
+    slice(od)['1:3000'] = 'aaaa'
+    slice(od)['3001:6000'] = 'bbbb'
+    slice(od)['6001:9000'] = 'cccc'
+    slice(od)['6001:9000'] = nil
+    slice(od)['6001:9000'] = 'dddd'
+
+    check(od, {
+        '1:3000 aaaa',
+        '3001:6000 bbbb',
+        '6001:9000 dddd',
+    })
+
+    -- This test case doesn't involve reindexing after reassigning
+    -- of the 6001:9000 fields. So, we check the order of
+    -- remaining values and don't check the maximum ID in the
+    -- internal key<->id mappings.
+end
+
+-- }}} Reindexing test cases

--- a/test/004_odict_test.lua
+++ b/test/004_odict_test.lua
@@ -2,6 +2,7 @@ local t = require 'luatest' --[[@as luatest]]
 local g = t.group('odict')
 
 local fun = require 'fun'
+local ffi = require 'ffi'
 local odict = require 'algo.odict'
 
 g.test_set_get = function()
@@ -115,6 +116,41 @@ g.test_pairs_delete_and_set = function()
         {'c', 3},
         {'b', 4},
     })
+end
+
+-- Using cdata as a key is unusual, but it is legal in LuaJIT.
+--
+-- There is a potential pitfall: ffi.new('void *') == nil. Let's
+-- verify that we handle such a key correctly.
+g.test_null_as_key = function()
+    local od = odict.new()
+
+    local nulls = {
+        ffi.new('void *'),
+        ffi.new('void *'),
+        ffi.new('void *'),
+    }
+
+    od[nulls[1]] = 1
+    od[nulls[2]] = 2
+    od[nulls[3]] = 3
+
+    local res = {}
+    for k, v in odict.pairs(od) do
+        table.insert(res, {k, v})
+    end
+
+    -- It doesn't differentiate nulls.
+    t.assert_equals(res, {
+        {nulls[1], 1},
+        {nulls[2], 2},
+        {nulls[3], 3},
+    })
+
+    -- It does.
+    t.assert(rawequal(res[1][1], nulls[1]))
+    t.assert(rawequal(res[2][1], nulls[2]))
+    t.assert(rawequal(res[3][1], nulls[3]))
 end
 
 -- {{{ Helpers for reindexing test cases


### PR DESCRIPTION
The module is inspired by Python's collections.OrderedDict. See the description in the module code for details.

Borrowed from https://github.com/tarantool/tarantool/pull/9730